### PR TITLE
Fixed Project name for Gradle autodetection

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'marketplace'
+rootProject.name = 'MarketPlace'


### PR DESCRIPTION
Gradle wasn't able to fetch the project name automatically due to a name mismatch in the project folder and `settings.gradle` file. 